### PR TITLE
Insignificant changes

### DIFF
--- a/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
+++ b/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
@@ -136,15 +136,15 @@ open class ScrollingStackViewController: UIViewController {
     open func insert(viewController: UIViewController, at index: Int) {
         
         addChildViewController(viewController)
-        viewController.didMove(toParentViewController: self)
-        
         stackView.insertArrangedSubview(viewController.view, at: index)
+        viewController.didMove(toParentViewController: self)
     }
     
     open func remove(viewController: UIViewController) {
         
+        guard childViewControllers.contains(where: { $0 === viewController }) else { return }
+        viewController.willMove(toParentViewController: nil)
         stackView.removeArrangedSubview(viewController.view)
-        
         viewController.removeFromParentViewController()
     }
     


### PR DESCRIPTION
When adding a child view controller, call `didMoveToParentViewController` on child after view setup is complete. While not necessary, because we have no transitions at the moment, it's still a nice touch.

When removing a child view controller, call `willMoveToParentViewController` on the child, so that the child could prepare itself before its view will be removed from view hierarchy.