### PR TITLE
CPD-14518: Container behaviour

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ScrollingStackViewController (3.1.2)
+  - ScrollingStackViewController (4.0.0)
 
 DEPENDENCIES:
   - ScrollingStackViewController (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ScrollingStackViewController: da1156942456d39a23313c6bd36d9f9bf01142ea
+  ScrollingStackViewController: c87977311c6e8b0c4d32fcf9530dd60250d9c470
 
 PODFILE CHECKSUM: 1107023c97aaa6562f2eb38595e37b1267bba2b1
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ScrollingStackViewController (3.1.1)
+  - ScrollingStackViewController (3.1.2)
 
 DEPENDENCIES:
   - ScrollingStackViewController (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ScrollingStackViewController: 62b8043cae3b839c400f358bbc70185dee48edd4
+  ScrollingStackViewController: da1156942456d39a23313c6bd36d9f9bf01142ea
 
 PODFILE CHECKSUM: 1107023c97aaa6562f2eb38595e37b1267bba2b1
 

--- a/Example/Pods/Local Podspecs/ScrollingStackViewController.podspec.json
+++ b/Example/Pods/Local Podspecs/ScrollingStackViewController.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ScrollingStackViewController",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "summary": "A view controller that uses root views of child view controllers as views in a UIStackView.",
   "description": "This view controller is more suitable than an UITableViewController when creating a list of segments that are dynamically behaving, but are well defined and bound in number. The delegation pattern that the data source of an UITableViewController is best suited for situation when there is an unbounded number of cells, but in many cases is an overkill and becomes a burden. Also, UITableViewCells are not controllers, but sometimes it makes sense to properly partition the responsibility of the segments, not just over the view layer. Using ScrollingStackViewController you can have a bunch of view controllers, each of them encapsulating their own responsibilities.",
   "homepage": "https://github.com/justeat/ScrollingStackViewController",
@@ -15,7 +15,7 @@
   },
   "source": {
     "git": "https://github.com/justeat/ScrollingStackViewController.git",
-    "tag": "3.1.1"
+    "tag": "3.1.2"
   },
   "platforms": {
     "ios": "9.0"

--- a/Example/Pods/Local Podspecs/ScrollingStackViewController.podspec.json
+++ b/Example/Pods/Local Podspecs/ScrollingStackViewController.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ScrollingStackViewController",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "summary": "A view controller that uses root views of child view controllers as views in a UIStackView.",
   "description": "This view controller is more suitable than an UITableViewController when creating a list of segments that are dynamically behaving, but are well defined and bound in number. The delegation pattern that the data source of an UITableViewController is best suited for situation when there is an unbounded number of cells, but in many cases is an overkill and becomes a burden. Also, UITableViewCells are not controllers, but sometimes it makes sense to properly partition the responsibility of the segments, not just over the view layer. Using ScrollingStackViewController you can have a bunch of view controllers, each of them encapsulating their own responsibilities.",
   "homepage": "https://github.com/justeat/ScrollingStackViewController",
@@ -15,7 +15,7 @@
   },
   "source": {
     "git": "https://github.com/justeat/ScrollingStackViewController.git",
-    "tag": "3.1.2"
+    "tag": "4.0.0"
   },
   "platforms": {
     "ios": "9.0"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ScrollingStackViewController (3.1.2)
+  - ScrollingStackViewController (4.0.0)
 
 DEPENDENCIES:
   - ScrollingStackViewController (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ScrollingStackViewController: da1156942456d39a23313c6bd36d9f9bf01142ea
+  ScrollingStackViewController: c87977311c6e8b0c4d32fcf9530dd60250d9c470
 
 PODFILE CHECKSUM: 1107023c97aaa6562f2eb38595e37b1267bba2b1
 

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ScrollingStackViewController (3.1.1)
+  - ScrollingStackViewController (3.1.2)
 
 DEPENDENCIES:
   - ScrollingStackViewController (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ScrollingStackViewController: 62b8043cae3b839c400f358bbc70185dee48edd4
+  ScrollingStackViewController: da1156942456d39a23313c6bd36d9f9bf01142ea
 
 PODFILE CHECKSUM: 1107023c97aaa6562f2eb38595e37b1267bba2b1
 

--- a/Example/Pods/Target Support Files/ScrollingStackViewController/Info.plist
+++ b/Example/Pods/Target Support Files/ScrollingStackViewController/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.1.1</string>
+  <string>3.1.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/ScrollingStackViewController/Info.plist
+++ b/Example/Pods/Target Support Files/ScrollingStackViewController/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>3.1.2</string>
+  <string>4.0.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -50,8 +50,17 @@ class ViewController: ScrollingStackViewController {
 Insert a child view controller at position.
 
 ``` Swift
-insert(viewController: viewController3, at: 1)
+insert(viewController: viewController3, at: .index(1))
 ```
+
+Insert a child view controller with padding (child view is added to a container view). NB: When a child view is added to a padding container view, the show/hide functions should be used.
+``` Swift
+insert(viewController: viewController4,
+           edgeInsets: UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8),
+                   at: .after(viewController3))
+```
+
+
 
 Remove a child view controller. NB: Might be easier to just add all VCs you were planning to use and then just show and hide them as needed. See below.
 

--- a/ScrollingStackViewController.podspec
+++ b/ScrollingStackViewController.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ScrollingStackViewController'
-  s.version          = '3.1.2'
+  s.version          = '4.0.0'
   s.summary          = 'A view controller that uses root views of child view controllers as views in a UIStackView.'
 
   s.description      = <<-DESC

--- a/ScrollingStackViewController.podspec
+++ b/ScrollingStackViewController.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ScrollingStackViewController'
-  s.version          = '3.1.1'
+  s.version          = '3.1.2'
   s.summary          = 'A view controller that uses root views of child view controllers as views in a UIStackView.'
 
   s.description      = <<-DESC

--- a/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
+++ b/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
@@ -138,7 +138,7 @@ open class ScrollingStackViewController: UIViewController {
         insert(viewController: viewController)
     }
     
-    open func add(viewController: UIViewController, edgeInsets: UIEdgeInsets) {
+    open func add(viewController: UIViewController, edgeInsets: UIEdgeInsets? = nil) {
         insert(viewController: viewController, edgeInsets: edgeInsets)
     }
     
@@ -146,7 +146,7 @@ open class ScrollingStackViewController: UIViewController {
         insert(viewController: viewController, at: .index(index))
     }
     
-    open func insert(viewController: UIViewController, edgeInsets: UIEdgeInsets = .zero, at position: Position = .end) {
+    open func insert(viewController: UIViewController, edgeInsets: UIEdgeInsets? = nil, at position: Position = .end) {
         var insertionIndex: Int?
         
         switch position {
@@ -177,35 +177,37 @@ open class ScrollingStackViewController: UIViewController {
         insert(viewController: viewController, edgeInsets: edgeInsets, at: insertionIndex ?? childViewControllers.count)
     }
     
-    open func insert(viewController: UIViewController, edgeInsets: UIEdgeInsets, at index: Int) {
+    open func insert(viewController: UIViewController, edgeInsets: UIEdgeInsets?, at index: Int) {
 
         addChildViewController(viewController)
         viewController.didMove(toParentViewController: self)
         
-        let childView: UIView = viewController.view
-        let containerView = UIView()
-        containerView.translatesAutoresizingMaskIntoConstraints = false
-        childView.translatesAutoresizingMaskIntoConstraints = false
-        containerView.addSubview(childView)
-        
-        let constraints = [
-            childView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: edgeInsets.top),
-            childView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: edgeInsets.left),
-            containerView.bottomAnchor.constraint(equalTo: childView.bottomAnchor, constant: edgeInsets.bottom),
-            containerView.trailingAnchor.constraint(equalTo: childView.trailingAnchor, constant: edgeInsets.right),
-        ]
-        
-        NSLayoutConstraint.activate(constraints)
-        
-        stackView.insertArrangedSubview(containerView, at: index)
+        if let edgeInsets = edgeInsets {
+            
+            let childView: UIView = viewController.view
+            let containerView = UIView()
+            containerView.translatesAutoresizingMaskIntoConstraints = false
+            childView.translatesAutoresizingMaskIntoConstraints = false
+            containerView.addSubview(childView)
+            
+            let constraints = [
+                childView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: edgeInsets.top),
+                childView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: edgeInsets.left),
+                containerView.bottomAnchor.constraint(equalTo: childView.bottomAnchor, constant: edgeInsets.bottom),
+                containerView.trailingAnchor.constraint(equalTo: childView.trailingAnchor, constant: edgeInsets.right),
+                ]
+            
+            NSLayoutConstraint.activate(constraints)
+            stackView.insertArrangedSubview(containerView, at: index)
+            
+        } else {
+            stackView.insertArrangedSubview(viewController.view, at: index)
+        }
     }
     
     open func remove(viewController: UIViewController) {
-        
-        if let index = arrangedViewOrContainerIndex(for: viewController.view) {
-            let viewToRemove = stackView.arrangedSubviews[index]
-            stackView.removeArrangedSubview(viewToRemove)
-        }
+        guard let arrangedView = arrangedView(for: viewController) else { return }
+        stackView.removeArrangedSubview(arrangedView)
         
         viewController.willMove(toParentViewController: nil)
         viewController.removeFromParentViewController()

--- a/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
+++ b/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
@@ -221,8 +221,10 @@ open class ScrollingStackViewController: UIViewController {
         }
         
         animate({
-            viewController.view.alpha = 1
-            viewController.view.isHidden = false
+            if let view = self.arrangedView(for: viewController) {
+                view.alpha = 1
+                view.isHidden = false
+            }
         }, { isFinished in
             if isFinished {
                 action?()


### PR DESCRIPTION
Only add padding container view if necessary. Adding padding prevented the Stack View behaviour from functioning as expected when showing/hiding added views (unless Scrolling Stack View Controller show/hide methods were called explicitly).