### PR TITLE
New helper methods and improve layout constraints performance

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		C82CCD4C47AFA3FFD63C437E844CCD51 /* Pods-ScrollingStackViewController_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AA877DCE0957E0B4BF007D8965EB7567 /* Pods-ScrollingStackViewController_Example-dummy.m */; };
 		CF72750F115B93C98D32002B6BAD5536 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */; };
 		EE8676460714FFC710DA9E15DC3651B5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */; };
+		F5C103C12125F9300013842D /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C103C02125F9300013842D /* UIViewController+Extensions.swift */; };
+		F5C103C32125FA8D0013842D /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C103C22125FA8D0013842D /* UIView+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,15 +42,15 @@
 		069145D3BB377C98C73FE37836CDD76F /* ScrollingStackViewController.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = ScrollingStackViewController.xcconfig; sourceTree = "<group>"; };
 		08D1A0AE84B0EF7F1E8288E6577618E3 /* Pods-ScrollingStackViewController_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-ScrollingStackViewController_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		0A7BCD0966BB07589BBF13AE9F977FFB /* ScrollingStackViewController-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ScrollingStackViewController-umbrella.h"; sourceTree = "<group>"; };
-		0B73FD4FCC83EE093E130B4183F406A8 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
-		0DC2C7EB867D2C55C7122C2CECA75FD3 /* ScrollingStackViewController.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = ScrollingStackViewController.framework; path = ScrollingStackViewController.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0B73FD4FCC83EE093E130B4183F406A8 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		0DC2C7EB867D2C55C7122C2CECA75FD3 /* ScrollingStackViewController.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ScrollingStackViewController.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1D88BA078FA16A4093A588031B6A48CC /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		206046D77A9EB19178AAE8B0D3DCAB58 /* Pods-ScrollingStackViewController_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-ScrollingStackViewController_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		22C9D6241B9B2EB06A29F58BB9F0D6B3 /* Pods_ScrollingStackViewController_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_ScrollingStackViewController_Tests.framework; path = "Pods-ScrollingStackViewController_Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		22C9D6241B9B2EB06A29F58BB9F0D6B3 /* Pods_ScrollingStackViewController_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ScrollingStackViewController_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A4F2990C43611A7E7E1246750F97A94 /* ScrollingStackViewController-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "ScrollingStackViewController-prefix.pch"; sourceTree = "<group>"; };
-		2EDEA27328428A3F2A056304FFF69483 /* ScrollingStackViewController.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; path = ScrollingStackViewController.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		2EDEA27328428A3F2A056304FFF69483 /* ScrollingStackViewController.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; path = ScrollingStackViewController.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		349858655F3180648D1BEA29D060C8A9 /* Pods-ScrollingStackViewController_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-ScrollingStackViewController_Tests.modulemap"; sourceTree = "<group>"; };
-		4C17125603C70E65A494436E3D5B6C0B /* Pods_ScrollingStackViewController_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_ScrollingStackViewController_Example.framework; path = "Pods-ScrollingStackViewController_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C17125603C70E65A494436E3D5B6C0B /* Pods_ScrollingStackViewController_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ScrollingStackViewController_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F4BAF5DBF5E720FD916CC273EB3B95F /* Pods-ScrollingStackViewController_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-ScrollingStackViewController_Tests-umbrella.h"; sourceTree = "<group>"; };
 		5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		60D5C137F6E829692917BD1BA964BCEA /* Pods-ScrollingStackViewController_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-ScrollingStackViewController_Example-frameworks.sh"; sourceTree = "<group>"; };
@@ -60,8 +62,8 @@
 		6F0D45038715FA218FEA458FE02BC933 /* Pods-ScrollingStackViewController_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-ScrollingStackViewController_Tests-dummy.m"; sourceTree = "<group>"; };
 		772198DD37180653C201F6942E36CB4A /* Pods-ScrollingStackViewController_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-ScrollingStackViewController_Tests-frameworks.sh"; sourceTree = "<group>"; };
 		8708AA7D28F46985C8432D8380DFFEC7 /* Pods-ScrollingStackViewController_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ScrollingStackViewController_Example.release.xcconfig"; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9EA982813114E3DE73E6F6EA28BD6F3F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9EA982813114E3DE73E6F6EA28BD6F3F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		AA877DCE0957E0B4BF007D8965EB7567 /* Pods-ScrollingStackViewController_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-ScrollingStackViewController_Example-dummy.m"; sourceTree = "<group>"; };
 		BFD54CE3C3163335D400BA0DD6F4F870 /* Pods-ScrollingStackViewController_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-ScrollingStackViewController_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		C70B5048E29692E8E5AD9A980CC0549E /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -71,6 +73,8 @@
 		E53FF618795305E20A788BC2416A88A9 /* ScrollingStackViewController.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = ScrollingStackViewController.modulemap; sourceTree = "<group>"; };
 		E57FEB34703E935C7D644755E880F84D /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F182245C5956E3D14A6CB4814D465B02 /* Pods-ScrollingStackViewController_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-ScrollingStackViewController_Example.modulemap"; sourceTree = "<group>"; };
+		F5C103C02125F9300013842D /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIViewController+Extensions.swift"; path = "ScrollingStackViewController/Classes/UIViewController+Extensions.swift"; sourceTree = "<group>"; };
+		F5C103C22125FA8D0013842D /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIView+Extensions.swift"; path = "ScrollingStackViewController/Classes/UIView+Extensions.swift"; sourceTree = "<group>"; };
 		FF9B13A37B52D1FEE00F7BBE0951559B /* Pods-ScrollingStackViewController_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-ScrollingStackViewController_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -127,6 +131,8 @@
 		2A6FEC01232EC3F1BF308C58F98D8CD8 /* ScrollingStackViewController */ = {
 			isa = PBXGroup;
 			children = (
+				F5C103C22125FA8D0013842D /* UIView+Extensions.swift */,
+				F5C103C02125F9300013842D /* UIViewController+Extensions.swift */,
 				6B76DF5BCA80711B41384D0110A7B5F7 /* ScrollingStackViewController.swift */,
 				92DC44DB740958E41EB49C384F499B00 /* Pod */,
 				0D6E6D0EADDB174F21110E12666CD4E5 /* Support Files */,
@@ -352,6 +358,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				501037FC9A29EB7CAEEA7B089DAFEB37 /* ScrollingStackViewController-dummy.m in Sources */,
+				F5C103C12125F9300013842D /* UIViewController+Extensions.swift in Sources */,
+				F5C103C32125FA8D0013842D /* UIView+Extensions.swift in Sources */,
 				0202B9905E1F949B03A3E0A8CF3E7E3C /* ScrollingStackViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ScrollingStackViewController/Classes/UIView+Extensions.swift
+++ b/ScrollingStackViewController/Classes/UIView+Extensions.swift
@@ -1,0 +1,31 @@
+
+extension Array where Element: NSLayoutConstraint {
+    public func activate() {
+        NSLayoutConstraint.activate(self)
+    }
+}
+
+extension UIScrollView {
+    var maxOffsetY: CGFloat {
+        return contentSize.height - frame.size.height
+    }
+}
+
+extension UIView {
+    
+    public func embedded(with edgetInsets: UIEdgeInsets) -> UIView {
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        self.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(self)
+        
+        let constraints = [
+            self.topAnchor.constraint(equalTo: containerView.topAnchor, constant: edgetInsets.top),
+            self.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: edgetInsets.left),
+            containerView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: edgetInsets.bottom),
+            containerView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: edgetInsets.right),
+            ].activate()
+    
+        return containerView
+    }
+}

--- a/ScrollingStackViewController/Classes/UIViewController+Extensions.swift
+++ b/ScrollingStackViewController/Classes/UIViewController+Extensions.swift
@@ -1,0 +1,27 @@
+
+extension UIViewController {
+    func view(withEdgeInsets edgeInsets: UIEdgeInsets?) -> UIView {
+        guard let edgeInsets = edgeInsets else { return view }
+        return view.embedded(with: edgeInsets)
+    }
+    
+    func add(_ child: UIViewController, addingView: Bool = true) {
+        addChildViewController(child)
+        if addingView {
+            view.addSubview(child.view)
+        }
+        child.didMove(toParentViewController: self)
+    }
+    
+    func removeAsChild(removingView: Bool = true) {
+        guard parent != nil else {
+            return
+        }
+        
+        willMove(toParentViewController: nil)
+        removeFromParentViewController()
+        if removingView {
+            view.removeFromSuperview()
+        }
+    }
+}


### PR DESCRIPTION
* Create some extensions with helper methods.
* Modify NSLayoutConstraints activation. Taking account the [Apple doc](https://developer.apple.com/documentation/uikit/nslayoutconstraint/1526955-activate), activate a set of constraints with one call is more efficient than activating each constraint individually.
* Move some logic from UIViewController lifecycle methods to private methods, in order to clarify what they do.