### PR TITLE
Fixed view not removed from heirarchy on removal

### DIFF
--- a/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
+++ b/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
@@ -207,8 +207,8 @@ open class ScrollingStackViewController: UIViewController {
     
     open func remove(viewController: UIViewController) {
         guard let arrangedView = arrangedView(for: viewController) else { return }
-        stackView.removeArrangedSubview(arrangedView)
-        
+        arrangedView.removeFromSuperview()
+      
         viewController.willMove(toParentViewController: nil)
         viewController.removeFromParentViewController()
     }


### PR DESCRIPTION
UIStackView's `removeArrangedSubView` method does not remove the view from the view heirarchy*, and so, the `remove(viewController:)` method does not work as expected. This fixes the issue.

*From the docs:

> Removes a subview from the list of arranged subviews without removing it as a subview of the receiver. To remove the view as a subview, send it -removeFromSuperview as usual;
the relevant UIStackView will remove it from its arrangedSubviews list automatically.

