### PR TITLE
View controller removal bug

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ScrollingStackViewController (4.0.0)
+  - ScrollingStackViewController (4.0.1)
 
 DEPENDENCIES:
   - ScrollingStackViewController (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ScrollingStackViewController: c87977311c6e8b0c4d32fcf9530dd60250d9c470
+  ScrollingStackViewController: ae954d22a57508749a58c5ffb01231a8dba2817d
 
 PODFILE CHECKSUM: 1107023c97aaa6562f2eb38595e37b1267bba2b1
 

--- a/Example/Pods/Local Podspecs/ScrollingStackViewController.podspec.json
+++ b/Example/Pods/Local Podspecs/ScrollingStackViewController.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ScrollingStackViewController",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "summary": "A view controller that uses root views of child view controllers as views in a UIStackView.",
   "description": "This view controller is more suitable than an UITableViewController when creating a list of segments that are dynamically behaving, but are well defined and bound in number. The delegation pattern that the data source of an UITableViewController is best suited for situation when there is an unbounded number of cells, but in many cases is an overkill and becomes a burden. Also, UITableViewCells are not controllers, but sometimes it makes sense to properly partition the responsibility of the segments, not just over the view layer. Using ScrollingStackViewController you can have a bunch of view controllers, each of them encapsulating their own responsibilities.",
   "homepage": "https://github.com/justeat/ScrollingStackViewController",
@@ -15,7 +15,7 @@
   },
   "source": {
     "git": "https://github.com/justeat/ScrollingStackViewController.git",
-    "tag": "4.0.0"
+    "tag": "4.0.1"
   },
   "platforms": {
     "ios": "9.0"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - ScrollingStackViewController (4.0.0)
+  - ScrollingStackViewController (4.0.1)
 
 DEPENDENCIES:
   - ScrollingStackViewController (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  ScrollingStackViewController: c87977311c6e8b0c4d32fcf9530dd60250d9c470
+  ScrollingStackViewController: ae954d22a57508749a58c5ffb01231a8dba2817d
 
 PODFILE CHECKSUM: 1107023c97aaa6562f2eb38595e37b1267bba2b1
 

--- a/Example/Pods/Target Support Files/ScrollingStackViewController/Info.plist
+++ b/Example/Pods/Target Support Files/ScrollingStackViewController/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.0.0</string>
+  <string>4.0.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Tests/ScrollingStackViewTests.swift
+++ b/Example/Tests/ScrollingStackViewTests.swift
@@ -59,6 +59,28 @@ class ScrollingStackViewTests: XCTestCase {
         vc.remove(viewController: child2)
         XCTAssert(vc.stackView.arrangedSubviews.count == 1)
     }
+    
+    func testRemoveViewControllers() {
+        let vc = Factory.createScrollingStackViewController(window: window)
+        let height = vc.view.frame.height
+        
+        let child1 = Factory.createStubViewController(height: height)
+        let child2 = Factory.createStubViewController(height: height)
+        let edgeInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        
+        vc.add(viewController: child1)
+        vc.show(viewController: child1)
+        vc.show(viewController: child2, insertIfNeeded: (position: .end, insets: edgeInset))
+        XCTAssert(vc.stackView.arrangedSubviews.count == 2)
+        
+        vc.remove(viewController: child1)
+        XCTAssert(vc.stackView.arrangedSubviews.count == 1)
+        XCTAssert(child1.view.superview == nil)
+        
+        vc.remove(viewController: child2)
+        XCTAssert(vc.stackView.arrangedSubviews.count == 0)
+        XCTAssert(child2.view.superview == nil)
+    }
 
     func testComplexScrolling() {
         

--- a/Example/Tests/ScrollingStackViewTests.swift
+++ b/Example/Tests/ScrollingStackViewTests.swift
@@ -73,16 +73,13 @@ class ScrollingStackViewTests: XCTestCase {
         vc.show(viewController: containedVC, insertIfNeeded: (position: .end, insets: edgeInset))
         XCTAssert(vc.stackView.arrangedSubviews.count == 2)
         
-        let firstArrangedView = arrangedVC.view!
-        let secondArrangedView = containedVC.view.superview!
-        
         vc.remove(viewController: arrangedVC)
         XCTAssert(vc.stackView.arrangedSubviews.count == 1)
-        XCTAssert(firstArrangedView.superview == nil)
+        XCTAssert(arrangedVC.view.superview == nil)
         
         vc.remove(viewController: containedVC)
         XCTAssert(vc.stackView.arrangedSubviews.count == 0)
-        XCTAssert(secondArrangedView.superview == nil)
+        XCTAssert(containedVC.view.superview == nil)
     }
 
     func testComplexScrolling() {

--- a/Example/Tests/ScrollingStackViewTests.swift
+++ b/Example/Tests/ScrollingStackViewTests.swift
@@ -64,22 +64,25 @@ class ScrollingStackViewTests: XCTestCase {
         let vc = Factory.createScrollingStackViewController(window: window)
         let height = vc.view.frame.height
         
-        let child1 = Factory.createStubViewController(height: height)
-        let child2 = Factory.createStubViewController(height: height)
+        let arrangedVC = Factory.createStubViewController(height: height)
+        let containedVC = Factory.createStubViewController(height: height)
         let edgeInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
         
-        vc.add(viewController: child1)
-        vc.show(viewController: child1)
-        vc.show(viewController: child2, insertIfNeeded: (position: .end, insets: edgeInset))
+        vc.add(viewController: arrangedVC)
+        vc.show(viewController: arrangedVC)
+        vc.show(viewController: containedVC, insertIfNeeded: (position: .end, insets: edgeInset))
         XCTAssert(vc.stackView.arrangedSubviews.count == 2)
         
-        vc.remove(viewController: child1)
-        XCTAssert(vc.stackView.arrangedSubviews.count == 1)
-        XCTAssert(child1.view.superview == nil)
+        let firstArrangedView = arrangedVC.view!
+        let secondArrangedView = containedVC.view.superview!
         
-        vc.remove(viewController: child2)
+        vc.remove(viewController: arrangedVC)
+        XCTAssert(vc.stackView.arrangedSubviews.count == 1)
+        XCTAssert(firstArrangedView.superview == nil)
+        
+        vc.remove(viewController: containedVC)
         XCTAssert(vc.stackView.arrangedSubviews.count == 0)
-        XCTAssert(child2.view.superview == nil)
+        XCTAssert(secondArrangedView.superview == nil)
     }
 
     func testComplexScrolling() {

--- a/ScrollingStackViewController.podspec
+++ b/ScrollingStackViewController.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ScrollingStackViewController'
-  s.version          = '4.0.0'
+  s.version          = '4.0.1'
   s.summary          = 'A view controller that uses root views of child view controllers as views in a UIStackView.'
 
   s.description      = <<-DESC

--- a/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
+++ b/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
@@ -207,8 +207,7 @@ open class ScrollingStackViewController: UIViewController {
     
     open func remove(viewController: UIViewController) {
         guard let arrangedView = arrangedView(for: viewController) else { return }
-        stackView.removeArrangedSubview(arrangedView)
-        viewController.view.removeFromSuperview()
+        arrangedView.removeFromSuperview()
         
         viewController.willMove(toParentViewController: nil)
         viewController.removeFromParentViewController()

--- a/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
+++ b/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
@@ -208,6 +208,7 @@ open class ScrollingStackViewController: UIViewController {
     open func remove(viewController: UIViewController) {
         guard let arrangedView = arrangedView(for: viewController) else { return }
         stackView.removeArrangedSubview(arrangedView)
+        viewController.view.removeFromSuperview()
         
         viewController.willMove(toParentViewController: nil)
         viewController.removeFromParentViewController()

--- a/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
+++ b/ScrollingStackViewController/Classes/ScrollingStackViewController.swift
@@ -208,6 +208,9 @@ open class ScrollingStackViewController: UIViewController {
     open func remove(viewController: UIViewController) {
         guard let arrangedView = arrangedView(for: viewController) else { return }
         arrangedView.removeFromSuperview()
+        if arrangedView != viewController.view {
+            viewController.view.removeFromSuperview()
+        }
         
         viewController.willMove(toParentViewController: nil)
         viewController.removeFromParentViewController()


### PR DESCRIPTION
Fix bug where a ViewController's view was not removed from it's superview when calling remove(viewController: UIViewController) if it was embedded in a 'padding view'.